### PR TITLE
use core instead of std in newtype_enum.

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -33,8 +33,8 @@ macro_rules! newtype_enum (
     (impl display $name:ident {$($body:tt)*}) => (
         newtype_enum!(impl $name { $($body)* });
 
-        impl ::std::fmt::Display for $name {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        impl ::core::fmt::Display for $name {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 newtype_enum!(@collect_disp, $name, f, self.0, $($body)*)
             }
         }
@@ -44,8 +44,8 @@ macro_rules! newtype_enum (
     (impl debug $name:ident {$($body:tt)*}) => (
         newtype_enum!(impl display $name { $($body)* });
 
-        impl ::std::fmt::Debug for $name {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        impl ::core::fmt::Debug for $name {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(f, "{}", self)
             }
         }


### PR DESCRIPTION
I want to use repo der-parse in an embedded environment, but it relies on a non-no-std `newtype_enum` macro.