### PR TITLE
Reduce nom deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ categories = ["parsing"]
 readme = "README.md"
 
 [dependencies]
-nom = "6.0"
+nom = { version = "6.0", default-features = false, features = ["std"] }


### PR DESCRIPTION
This contains an API change to remove dbg_dmp_rest, a function for which I could find no public users.

This allows disabling nom default features, which reduces the dependency footprint of the various rusticata crates (from x509-parser down) a lot.