### PR TITLE
Add no-std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,11 @@ nom = { version = "7.0", default-features = false, features = ["alloc"] }
 [features]
 default = ["std"]
 std = ["nom/std"]
+
+
+# docs.rs-specific configuration
+[package.metadata.docs.rs]
+# document all features
+all-features = true
+# defines the configuration attribute `docsrs`
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,8 @@ categories = ["parsing"]
 readme = "README.md"
 
 [dependencies]
-nom = { version = "7.0", default-features = false, features = ["std"] }
+nom = { version = "7.0", default-features = false, features = ["alloc"] }
+
+[features]
+default = ["std"]
+std = ["nom/std"]

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -9,6 +9,7 @@ use nom::{
 };
 
 /// Dump the remaining bytes to stderr, formatted as hex
+/// Note
 #[cfg(feature = "std")]
 pub fn dbg_dmp_rest(i: &[u8]) -> IResult<&[u8], ()> {
     map(peek(rest), |r: &[u8]| eprintln!("\n{}\n", r.to_hex(16)))(i)

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -9,7 +9,6 @@ use nom::{
 };
 
 /// Dump the remaining bytes to stderr, formatted as hex
-/// Note
 #[cfg(feature = "std")]
 pub fn dbg_dmp_rest(i: &[u8]) -> IResult<&[u8], ()> {
     map(peek(rest), |r: &[u8]| eprintln!("\n{}\n", r.to_hex(16)))(i)

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,11 +1,15 @@
 //! Helper functions and structures for debugging purpose
 
-use nom::combinator::{map, peek, rest};
-use nom::HexDisplay;
-use nom::IResult;
-use std::fmt;
+use alloc::{format, vec::Vec};
+use core::fmt;
+#[cfg(feature = "std")]
+use nom::{
+    combinator::{map, peek, rest},
+    HexDisplay, IResult,
+};
 
 /// Dump the remaining bytes to stderr, formatted as hex
+#[cfg(feature = "std")]
 pub fn dbg_dmp_rest(i: &[u8]) -> IResult<&[u8], ()> {
     map(peek(rest), |r: &[u8]| eprintln!("\n{}\n", r.to_hex(16)))(i)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,9 @@
     unused_import_braces,
     unused_qualifications
 )]
+#![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
 pub mod combinator;
 pub mod debug;
 pub use macros::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,9 @@
     unused_qualifications
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
+// only enables the `doc_cfg` feature when
+// the `docsrs` configuration attribute is defined
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 extern crate alloc;
 pub mod combinator;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,7 @@
 //! Common traits
 
+use alloc::vec::Vec;
+
 /// Common trait for structures serialization
 pub trait Serialize<O = Vec<u8>> {
     /// Type of serialization error


### PR DESCRIPTION
Takes changes from #6 and adds better documentation.

This PR enables builds on `no_std` targets when the default `std` feature is not enabled. I don't believe this will break backwards compatibility unless a downstream dependent had specified `default-features = false` in their `Cargo.toml` dependency list. That should be an extremely rare to non-existent case since before this PR this crate did not offer any features default or not.

Rather than modify the docs of `dbg_dmp_rest` I attempted to make use of `doc_auto_cfg`. Using this `cargo doc` will automatically add a tag indicating that `dbg_dump_rest` requires the `std` feature. I have tested this locally using the following command: `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features` and get the below result:
https://imgur.com/y7vT35y

I have also attempted to set up the `Cargo.toml` so that that will all work properly on docs.rs but don't have a way to test that. Most of the `doc_auto_cfg` stuff came from this stackoverflow page: https://stackoverflow.com/questions/61417452/how-to-get-a-feature-requirement-tag-in-the-documentation-generated-by-cargo-do

If all of that is too complicated though I am happy to revert that last docs commit and just manually add a sentence to the `dbg_dmp_rest` docs
